### PR TITLE
docs: update Xpoz CLI install link

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -6,7 +6,7 @@
 The easiest way to install Xpoz CLI:
 
 ```bash
-curl -fsSL https://get.xpoz.xyz/install.sh | bash
+curl -fsSL https://cli.xpoz.xyz/install.sh | bash
 ```
 ### This script will:
 


### PR DESCRIPTION
Replaced the old install link (https://get.xpoz.xyz/install.sh) with the updated one (https://cli.xpoz.xyz/install.sh) in the documentation to ensure users install Xpoz CLI from the correct source.